### PR TITLE
feature: 오류 객체 통일화

### DIFF
--- a/src/http-exception.filter.ts
+++ b/src/http-exception.filter.ts
@@ -5,6 +5,7 @@ import {
 	HttpException,
 	HttpStatus,
 	InternalServerErrorException,
+	Logger,
 } from '@nestjs/common';
 import { Request, Response } from 'express';
 import { ResponseDto } from './dto/response.dto';
@@ -39,10 +40,10 @@ export class HttpExceptionFilter implements ExceptionFilter {
 			errorString = errorString.toUpperCase().replaceAll(' ', '_');
 
 			// 자동으로 던저진 에러의 메세지는 배열형식이므로 이것을 개행문자로 붙여줍니다.
-			let message = messageList.join('\n');
+			const message = messageList.join('\n');
 
 			// responseDto 의 데이터 영역에 기존 에러의 리스폰스 객체를 넣어서 원문을 확인 할 수 있도록 합니다.
-			let responseDto = new ResponseDto(statusCode, errorString, true, message, { response });
+			const responseDto = new ResponseDto(statusCode, errorString, true, message, { response });
 
 			response = responseDto;
 		}
@@ -52,6 +53,8 @@ export class HttpExceptionFilter implements ExceptionFilter {
 			url: req.url,
 			response,
 		};
+
+		Logger.error(log);
 
 		res.status((exception as HttpException).getStatus()).json(response);
 	}

--- a/src/http-exception.filter.ts
+++ b/src/http-exception.filter.ts
@@ -1,0 +1,58 @@
+import {
+	ArgumentsHost,
+	Catch,
+	ExceptionFilter,
+	HttpException,
+	HttpStatus,
+	InternalServerErrorException,
+} from '@nestjs/common';
+import { Request, Response } from 'express';
+import { ResponseDto } from './dto/response.dto';
+import { ResponseCode } from './response.code.enum';
+import { ResponseMessage } from './response.message.enum';
+
+@Catch()
+export class HttpExceptionFilter implements ExceptionFilter {
+	catch(exception: Error, host: ArgumentsHost) {
+		const ctx = host.switchToHttp();
+		const res = ctx.getResponse<Response>();
+		const req = ctx.getRequest<Request>();
+
+		// HttpException이 아니라면 ETC 예외처리
+		if (!(exception instanceof HttpException)) {
+			// exception = new InternalServerErrorException();
+			exception = new HttpException(
+				new ResponseDto(HttpStatus.INTERNAL_SERVER_ERROR, ResponseCode.ETC, true, ResponseMessage.ETC),
+				HttpStatus.INTERNAL_SERVER_ERROR,
+			);
+		}
+
+		let response = (exception as HttpException).getResponse();
+
+		// DTO, 또는 로직에서 자동으로 던진 에러일 경우(명시적으로 던진 에러가 아닌경우)
+		if (response['statusCode']) {
+			const messageList = response['message'];
+			const statusCode = response['statusCode']; //HttpStatus Code
+			let errorString = response['error']; //error string
+
+			// errorString 을 resonseDto 에 넣기위해 컨벤션 맞추기
+			errorString = errorString.toUpperCase().replaceAll(' ', '_');
+
+			// 자동으로 던저진 에러의 메세지는 배열형식이므로 이것을 개행문자로 붙여줍니다.
+			let message = messageList.join('\n');
+
+			// responseDto 의 데이터 영역에 기존 에러의 리스폰스 객체를 넣어서 원문을 확인 할 수 있도록 합니다.
+			let responseDto = new ResponseDto(statusCode, errorString, true, message, { response });
+
+			response = responseDto;
+		}
+
+		const log = {
+			timestamp: new Date(),
+			url: req.url,
+			response,
+		};
+
+		res.status((exception as HttpException).getStatus()).json(response);
+	}
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,10 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { HttpExceptionFilter } from './http-exception.filter';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
-  await app.listen(8080);
+	const app = await NestFactory.create(AppModule);
+	app.useGlobalFilters(new HttpExceptionFilter());
+	await app.listen(8080);
 }
 bootstrap();


### PR DESCRIPTION
feature: 오류 객체 통일화

- 기존에는 명시적으로 던진 오류에 한해서만 오류 양식이 통일되었던 문제수정

현재
* 명시적 에러
```json
{
    "status": 404,
    "code": "WRONG_EMAIL_OR_PASSWORD",
    "error": true,
    "message": "잘못된 이메일 또는 비밀번호 입니다."
}
```

* 자동으로 Server 가 던지는 에러 (만일을 대비해 기존 에러 객체를 데이터에 담아 내림)
```json
{
    "status": 400,
    "code": "BAD_REQUEST",
    "error": true,
    "message": "email must be an email\npassword must be longer than or equal to 8 characters",
    "data": {
        "response": {
            "statusCode": 400,
            "message": [
                "email must be an email",
                "password must be longer than or equal to 8 characters"
            ],
            "error": "Bad Request"
        }
    }
}
```
